### PR TITLE
Allow media uploading while registration

### DIFF
--- a/backend/services/media/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
+++ b/backend/services/media/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
@@ -4,11 +4,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.http.HttpMethod.GET;
 
 /**
  * @see <a href=https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html>JWT and Spring Security</a>
@@ -22,8 +21,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/error").permitAll()
 
-                        .requestMatchers(GET, "/media/**").permitAll()
-                        .requestMatchers("/media/**").hasAuthority("SCOPE_media:write")
+                        .requestMatchers("/media/**").permitAll()
 
                         .requestMatchers("/swagger-ui.html").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
@@ -35,6 +33,7 @@ public class WebSecurityConfig {
                                 jwt -> jwt.decoder(jwtDecoder)
                         )
                 )
+                .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();

--- a/backend/services/media/src/test/java/pw/mer/letsplay/media/MediaSecurityTests.java
+++ b/backend/services/media/src/test/java/pw/mer/letsplay/media/MediaSecurityTests.java
@@ -5,7 +5,7 @@ import pw.mer.letsplay.AbstractControllerTests;
 import pw.mer.shared.SharedAuthFactory;
 
 import static io.restassured.RestAssured.given;
-import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static pw.mer.shared.RequestHelpers.authRequest;
 
 class MediaSecurityTests extends AbstractControllerTests {
@@ -22,18 +22,23 @@ class MediaSecurityTests extends AbstractControllerTests {
     }
 
     @Test
-    void unauthorized() {
+    void unauthorizedCanUpload() {
         var mediaData = TestMediaFactory.generateRandomData(1024);
 
-        given()
+        var testMedia = new TestMediaFactory.TestMedia(mediaData, "image/png");
+
+        var mediaId = given()
                 .multiPart("file", "file",
                         mediaData, "image/png")
                 .post("/media/upload")
-                .then().statusCode(SC_FORBIDDEN);
+                .then().statusCode(SC_CREATED)
+                .extract().body().asString();
+
+        testMedia.requestCheck(mediaId);
     }
 
     @Test
-    void nonAdmin() {
+    void nonAdminCanUpload() {
         var mediaData = TestMediaFactory.generateRandomData(1024);
 
         var token = getAccessToken(new SharedAuthFactory.TestUser());
@@ -42,6 +47,6 @@ class MediaSecurityTests extends AbstractControllerTests {
                 .multiPart("file", "file",
                         mediaData, "image/png")
                 .post("/media/upload")
-                .then().statusCode(SC_FORBIDDEN);
+                .then().statusCode(SC_CREATED);
     }
 }

--- a/backend/services/users/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
+++ b/backend/services/users/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
@@ -31,7 +31,7 @@ public class WebSecurityConfig {
 
                         .requestMatchers("/users/**").hasAuthority("SCOPE_users:admin")
 
-                        .requestMatchers("/swagger-ui.html").authenticated()
+                        .requestMatchers("/swagger-ui.html").permitAll()
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
 

--- a/backend/services/users/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
+++ b/backend/services/users/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PUT;
 
 /**
  * @see <a href=https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html>JWT and Spring Security</a>
@@ -28,6 +29,8 @@ public class WebSecurityConfig {
                         .requestMatchers(GET, "/users").hasAuthority("SCOPE_users:admin")
 
                         .requestMatchers(GET, "/users/**").permitAll()
+
+                        .requestMatchers(PUT, "/users/**").authenticated()
 
                         .requestMatchers("/users/**").hasAuthority("SCOPE_users:admin")
 

--- a/backend/services/users/src/main/java/pw/mer/letsplay/web/UserController.java
+++ b/backend/services/users/src/main/java/pw/mer/letsplay/web/UserController.java
@@ -54,7 +54,7 @@ public class UserController {
             return user;
         }
 
-        if (user.getRole() != ERole.SELLER) {
+        if (user.getRole() == ERole.USER) {
             throw new ResponseStatusException(NOT_FOUND, NOT_FOUND_MESSAGE);
         }
         return user;

--- a/backend/services/users/src/test/java/pw/mer/letsplay/user/UserSecurityTests.java
+++ b/backend/services/users/src/test/java/pw/mer/letsplay/user/UserSecurityTests.java
@@ -9,6 +9,7 @@ import static io.restassured.RestAssured.when;
 import static java.net.HttpURLConnection.*;
 import static org.hamcrest.Matchers.is;
 import static pw.mer.shared.RequestHelpers.authRequest;
+import static pw.mer.shared.RequestHelpers.jsonBodyRequest;
 
 class UserSecurityTests extends AbstractControllerTests {
     @Test
@@ -43,23 +44,21 @@ class UserSecurityTests extends AbstractControllerTests {
 
         String token = getAccessToken(testUser.email, testUser.password);
 
-        var req = given().auth().oauth2(token).when();
-
-        req.post("/users/add")
+        authRequest(token).post("/users/add")
                 .then()
                 .statusCode(HTTP_FORBIDDEN);
 
         var basicUser = new AuthFactory.TestUser();
         var basicUserId = basicUser.register().statusCode(HTTP_OK).extract().asString();
 
-        req.put("/users/" + basicUserId)
+        jsonBodyRequest(token, "{\"name\": \"new name\"}")
+                .put("/users/" + basicUserId)
                 .then()
                 .statusCode(HTTP_FORBIDDEN);
 
-        req.delete("/users/" + basicUserId)
+        authRequest(token).delete("/users/" + basicUserId)
                 .then()
                 .statusCode(HTTP_FORBIDDEN);
-
     }
 
     @Test

--- a/backend/services/users/src/test/java/pw/mer/letsplay/user/UserUpdateTests.java
+++ b/backend/services/users/src/test/java/pw/mer/letsplay/user/UserUpdateTests.java
@@ -3,6 +3,7 @@ package pw.mer.letsplay.user;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import pw.mer.letsplay.AbstractControllerTests;
+import pw.mer.letsplay.AuthFactory;
 
 import java.util.UUID;
 
@@ -197,5 +198,17 @@ class UserUpdateTests extends AbstractControllerTests {
         testUser.image = newImage;
 
         testUser.requestCheck(adminToken, testUserId);
+    }
+
+    @Test
+    void basicUserCanUpdateSelf() {
+        var testUser = new AuthFactory.TestUser();
+
+        String testUserId = testUser.register().statusCode(HTTP_OK).extract().asString();
+
+        String token = getAccessToken(testUser.email, testUser.password);
+
+        jsonBodyRequest(token, "{\"name\": \"new name\"}")
+                .put("/users/" + testUserId).then().statusCode(HTTP_OK);
     }
 }


### PR DESCRIPTION
This PR makes `POST /media/upload` public, so now users can upload images without authentication (e.g. during registration). The current implementation is quite simple, so there's no check if image was actually used to create a profile. We can implement it later as a cron job removing media which is not used by other microservices.

@adrian-lui, please feel free to provide any additional feedback about the backend, so we can resolve all `buy-01` issues here. 