### PR TITLE
Orders microservice

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -7,7 +7,7 @@ jobs:
   test-and-build:
     strategy:
       matrix:
-        services: [ users, products, media ]
+        services: [ users, products, media, orders ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/backend/services/orders/build.gradle.kts
+++ b/backend/services/orders/build.gradle.kts
@@ -1,0 +1,7 @@
+dependencies {
+    testImplementation(testFixtures(project(":shared")))
+    implementation(project(":shared"))
+
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/GlobalExceptionHandler.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/GlobalExceptionHandler.java
@@ -1,0 +1,8 @@
+package pw.mer.letsplay;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import pw.mer.shared.SharedGlobalExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends SharedGlobalExceptionHandler {
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/OrdersApplication.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/OrdersApplication.java
@@ -1,0 +1,11 @@
+package pw.mer.letsplay;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OrdersApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(OrdersApplication.class, args);
+    }
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/config/JwtConfig.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/config/JwtConfig.java
@@ -1,0 +1,8 @@
+package pw.mer.letsplay.config;
+
+import org.springframework.context.annotation.Configuration;
+import pw.mer.shared.config.SharedJwtConfig;
+
+@Configuration
+public class JwtConfig extends SharedJwtConfig {
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/config/SwaggerConfiguration.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/config/SwaggerConfiguration.java
@@ -1,0 +1,8 @@
+package pw.mer.letsplay.config;
+
+import org.springframework.context.annotation.Configuration;
+import pw.mer.shared.config.SharedSwaggerConfiguration;
+
+@Configuration
+public class SwaggerConfiguration extends SharedSwaggerConfiguration {
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/config/WebSecurityConfig.java
@@ -1,0 +1,46 @@
+package pw.mer.letsplay.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.http.HttpMethod.*;
+
+/**
+ * @see <a href=https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html>JWT and Spring Security</a>
+ */
+@Configuration
+@EnableMethodSecurity
+public class WebSecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtDecoder jwtDecoder) throws Exception {
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/error").permitAll()
+
+                        .requestMatchers(GET, "/orders/**").authenticated()
+                        .requestMatchers(POST, "/orders/add").authenticated()
+
+                        .requestMatchers(PUT, "/orders/**").hasAnyAuthority("SCOPE_orders:write", "SCOPE_orders:admin")
+
+                        .requestMatchers(DELETE, "/orders/**").hasAnyAuthority("SCOPE_orders:admin")
+
+                        .requestMatchers("/swagger-ui.html").permitAll()
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
+
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(
+                                jwt -> jwt.decoder(jwtDecoder)
+                        )
+                )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/model/EStatus.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/model/EStatus.java
@@ -1,0 +1,28 @@
+package pw.mer.letsplay.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.List;
+
+public enum EStatus {
+    PENDING,
+    CONFIRMED,
+    COMPLETED,
+    CANCELED;
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase();
+    }
+
+    public static EStatus fromString(String status) throws IllegalArgumentException {
+        if (status == null) {
+            return null;
+        }
+        return EStatus.valueOf(status.toUpperCase());
+    }
+
+    public static final String VALIDATION_MESSAGE = "Invalid status. Valid statuses are: " +
+            String.join(", ", List.of(EStatus.values()).toString());
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/model/Order.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/model/Order.java
@@ -24,7 +24,7 @@ public class Order {
     private String seller;
 
     @JsonProperty("products")
-    private List<String> products;
+    private List<Product> products;
 
     @JsonProperty("totalPrice")
     private Double totalPrice;
@@ -33,11 +33,16 @@ public class Order {
     @Setter
     private EStatus status;
 
-    public Order(String buyer, String seller, List<String> products, Double totalPrice) {
+    @JsonProperty("createdAt")
+    private Long createdAt;
+
+    public Order(String buyer, String seller, List<Product> products, Double totalPrice) {
         this.buyer = buyer;
         this.seller = seller;
         this.products = products;
         this.totalPrice = totalPrice;
         this.status = EStatus.PENDING;
+
+        this.createdAt = System.currentTimeMillis();
     }
 }

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/model/Order.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/model/Order.java
@@ -1,0 +1,43 @@
+package pw.mer.letsplay.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.List;
+
+@Getter
+@Document("Order")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Order {
+    @Id
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("buyer")
+    private String buyer;
+
+    @JsonProperty("seller")
+    private String seller;
+
+    @JsonProperty("products")
+    private List<String> products;
+
+    @JsonProperty("totalPrice")
+    private Double totalPrice;
+
+    @JsonProperty("status")
+    @Setter
+    private EStatus status;
+
+    public Order(String buyer, String seller, List<String> products, Double totalPrice) {
+        this.buyer = buyer;
+        this.seller = seller;
+        this.products = products;
+        this.totalPrice = totalPrice;
+        this.status = EStatus.PENDING;
+    }
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/model/Product.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/model/Product.java
@@ -1,0 +1,15 @@
+package pw.mer.letsplay.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Product {
+    @JsonProperty("id")
+    String id;
+
+    @JsonProperty("quantity")
+    Number quantity;
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/repository/OrdersRepo.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/repository/OrdersRepo.java
@@ -1,0 +1,12 @@
+package pw.mer.letsplay.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import pw.mer.letsplay.model.Order;
+
+import java.util.List;
+
+public interface OrdersRepo extends MongoRepository<Order, String> {
+    List<Order> findAllBySeller(String seller);
+
+    List<Order> findAllByBuyer(String buyer);
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/web/CustomErrorController.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/web/CustomErrorController.java
@@ -1,0 +1,8 @@
+package pw.mer.letsplay.web;
+
+import org.springframework.web.bind.annotation.RestController;
+import pw.mer.shared.web.SharedCustomErrorController;
+
+@RestController
+public class CustomErrorController extends SharedCustomErrorController {
+}

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/web/OrdersController.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/web/OrdersController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import pw.mer.letsplay.model.EStatus;
 import pw.mer.letsplay.model.Order;
+import pw.mer.letsplay.model.Product;
 import pw.mer.letsplay.repository.OrdersRepo;
 
 import java.util.List;
@@ -72,7 +73,7 @@ public class OrdersController {
     public static class AddOrderRequest {
         @JsonProperty("products")
         @NotEmpty(message = "Products is mandatory")
-        List<String> products;
+        List<Product> products;
 
         @JsonProperty("totalPrice")
         @NotNull(message = "Total price is mandatory")

--- a/backend/services/orders/src/main/java/pw/mer/letsplay/web/OrdersController.java
+++ b/backend/services/orders/src/main/java/pw/mer/letsplay/web/OrdersController.java
@@ -1,0 +1,145 @@
+package pw.mer.letsplay.web;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import pw.mer.letsplay.model.EStatus;
+import pw.mer.letsplay.model.Order;
+import pw.mer.letsplay.repository.OrdersRepo;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RestController
+@RequestMapping("/orders")
+public class OrdersController {
+    private final OrdersRepo ordersRepo;
+
+    private static final String NOT_FOUND_MESSAGE = "Order not found";
+
+    private static final String FORBIDDEN_MESSAGE = "You're not allowed to access this order";
+
+    @Autowired
+    public OrdersController(OrdersRepo ordersRepo) {
+        this.ordersRepo = ordersRepo;
+    }
+
+    @GetMapping
+    @SecurityRequirement(name = "Authentication")
+    public List<Order> index(Authentication authentication) {
+        if (isAdmin(authentication)) {
+            return ordersRepo.findAll();
+        }
+
+        var isSeller = authentication.getAuthorities().contains(new SimpleGrantedAuthority("SCOPE_orders:write"));
+
+        if (isSeller) {
+            return ordersRepo.findAllBySeller(authentication.getName());
+        }
+
+        var buyer = authentication.getName();
+
+        return ordersRepo.findAllByBuyer(buyer);
+    }
+
+    @GetMapping("/{id}")
+    @SecurityRequirement(name = "Authentication")
+    public Order getById(@PathVariable String id, Authentication authentication) {
+        var order = ordersRepo.findById(id).orElseThrow(() ->
+                new ResponseStatusException(NOT_FOUND, NOT_FOUND_MESSAGE));
+
+        var buyer = authentication.getName();
+        if (!isAdmin(authentication) &&
+                !buyer.equals(order.getSeller()) &&
+                !buyer.equals(order.getBuyer())
+        ) {
+            throw new ResponseStatusException(FORBIDDEN, FORBIDDEN_MESSAGE);
+        }
+
+        return order;
+    }
+
+    @Setter
+    public static class AddOrderRequest {
+        @JsonProperty("products")
+        @NotEmpty(message = "Products is mandatory")
+        List<String> products;
+
+        @JsonProperty("totalPrice")
+        @NotNull(message = "Total price is mandatory")
+        @PositiveOrZero(message = "Total price can not be negative")
+        Double totalPrice;
+
+        @JsonProperty("seller")
+        @NotEmpty(message = "Seller is mandatory")
+        String seller;
+    }
+
+
+    @PostMapping("/add")
+    @SecurityRequirement(name = "Authentication")
+    public String add(@Valid @RequestBody AddOrderRequest request, Authentication authentication) {
+        var buyer = authentication.getName();
+
+        var order = new Order(buyer, request.seller, request.products, request.totalPrice);
+        ordersRepo.save(order);
+
+        return order.getId();
+    }
+
+    @DeleteMapping("/{id}")
+    @SecurityRequirement(name = "Authentication", scopes = {"products:admin", "products:write"})
+    public void deleteById(@PathVariable String id, Authentication authentication) {
+        if (!ordersRepo.existsById(id)) {
+            throw new ResponseStatusException(NOT_FOUND, NOT_FOUND_MESSAGE);
+        }
+
+        if (!isAdmin(authentication)) {
+            throw new ResponseStatusException(FORBIDDEN, "Only admin can delete orders");
+        }
+
+        ordersRepo.deleteById(id);
+    }
+
+    @Setter
+    public static class UpdateOrderRequest {
+        @JsonProperty("status")
+        private Optional<String> status = Optional.empty();
+    }
+
+    @PutMapping("/{id}")
+    @SecurityRequirement(name = "Authentication")
+    public void updateById(@PathVariable String id, @Valid @RequestBody OrdersController.UpdateOrderRequest request, Authentication authentication) {
+        var order = ordersRepo.findById(id).orElseThrow(() -> new ResponseStatusException(NOT_FOUND, NOT_FOUND_MESSAGE));
+
+        var isAdmin = isAdmin(authentication);
+        var isOwner = order.getSeller().equals(authentication.getName());
+
+        if (!isAdmin && !isOwner) {
+            throw new ResponseStatusException(FORBIDDEN, FORBIDDEN_MESSAGE);
+        }
+
+        request.status.ifPresent(status -> {
+            try {
+                order.setStatus(EStatus.fromString(status));
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(BAD_REQUEST, EStatus.VALIDATION_MESSAGE);
+            }
+        });
+
+        ordersRepo.save(order);
+    }
+
+    boolean isAdmin(Authentication authentication) {
+        return authentication.getAuthorities().contains(new SimpleGrantedAuthority("SCOPE_orders:admin"));
+    }
+}

--- a/backend/services/orders/src/main/resources/application.yml
+++ b/backend/services/orders/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  data:
+    mongodb:
+      host: ${MONGO_HOST:localhost}
+
+security:
+  jwt:
+    secret: ${JWT_SECRET:UnsafeSecret}
+
+docs:
+  api-url: ${DOCS_API_URL:/}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/AbstractControllerTests.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/AbstractControllerTests.java
@@ -1,0 +1,31 @@
+package pw.mer.letsplay;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import pw.mer.letsplay.repository.OrdersRepo;
+import pw.mer.shared.SharedAuthFactory;
+import pw.mer.shared.SharedAbstractControllerTestsWithDB;
+import pw.mer.shared.config.SharedJwtConfig;
+
+import java.util.List;
+
+public abstract class AbstractControllerTests extends SharedAbstractControllerTestsWithDB {
+    @Autowired
+    private OrdersRepo ordersRepo;
+
+    public String getAdminToken() {
+        return getAccessToken(getAdmin());
+    }
+
+    public SharedAuthFactory.TestUser getAdmin() {
+        return new SharedAuthFactory.TestUser(List.of("orders:admin"));
+    }
+
+    public SharedAuthFactory.TestUser getSeller() {
+        return new SharedAuthFactory.TestUser(List.of("orders:write"));
+    }
+
+    @Override
+    public void clean() {
+        ordersRepo.deleteAll();
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/CustomErrorTests.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/CustomErrorTests.java
@@ -1,0 +1,51 @@
+package pw.mer.letsplay;
+
+import org.junit.jupiter.api.Test;
+
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+import static pw.mer.shared.RequestHelpers.authRequest;
+import static pw.mer.shared.RequestHelpers.jsonBodyRequest;
+
+class CustomErrorTests extends AbstractControllerTests {
+    @Test
+    void endpointDoesNotExist() {
+        String sellerToken = getAccessToken(getSeller());
+
+        authRequest(sellerToken).get("/no/such/endpoint")
+                .then().statusCode(HTTP_NOT_FOUND);
+    }
+
+    @Test
+    void errorsShouldFollowRFC7807() {
+        String sellerToken = getAccessToken(getSeller());
+
+        authRequest(sellerToken).get("/no/such/endpoint")
+                .then().statusCode(HTTP_NOT_FOUND)
+                .body("title", is(not(emptyOrNullString())),
+                        "status", is(HTTP_NOT_FOUND));
+
+        jsonBodyRequest(sellerToken, "{}").post("/orders/add")
+                .then().statusCode(HTTP_BAD_REQUEST)
+                .body("title", is(not(emptyOrNullString())),
+                        "status", is(HTTP_BAD_REQUEST),
+                        "detail", is(not(emptyOrNullString()))
+                );
+    }
+
+    @Test
+    void firewall() {
+        String sellerToken = getAccessToken(getSeller());
+
+        authRequest(sellerToken).get("//////this/is/not/allowed///")
+                .then().statusCode(HTTP_BAD_REQUEST);
+
+        authRequest(sellerToken).get("/orders;with=semicolon")
+                .then().statusCode(HTTP_BAD_REQUEST);
+
+        authRequest(sellerToken).request("TRACE", "/orders")
+                .then().statusCode(HTTP_BAD_REQUEST);
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderAddTests.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderAddTests.java
@@ -1,0 +1,52 @@
+package pw.mer.letsplay.order;
+
+import org.junit.jupiter.api.Test;
+import pw.mer.letsplay.AbstractControllerTests;
+import pw.mer.shared.SharedAuthFactory;
+
+import java.util.List;
+
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_OK;
+
+class OrderAddTests extends AbstractControllerTests {
+    @Test
+    void orderAddValid() {
+        var testUser = new SharedAuthFactory.TestUser();
+        String token = getAccessToken(testUser);
+
+        var testSeller = getSeller();
+
+        var order = new TestOrderFactory.TestOrder(testUser.getId(), testSeller.getId());
+
+        String orderId = order.requestAdd(token).statusCode(HTTP_OK).extract().asString();
+
+        order.requestCheck(token, orderId);
+    }
+
+    @Test
+    void orderAddInvalid() {
+        var testUser = new SharedAuthFactory.TestUser();
+        String token = getAccessToken(testUser);
+
+        var testSeller = new SharedAuthFactory.TestUser(List.of("orders:write"));
+
+        var order = new TestOrderFactory.TestOrder(testUser.getId(), testSeller.getId());
+
+        var brokenOrder = new TestOrderFactory.TestOrder(testUser.getId(), testSeller.getId());
+
+        brokenOrder.totalPrice = null;
+        brokenOrder.requestAdd(token).statusCode(HTTP_BAD_REQUEST);
+
+        brokenOrder.totalPrice = -1.0;
+        brokenOrder.requestAdd(token).statusCode(HTTP_BAD_REQUEST);
+
+        brokenOrder = order;
+
+        brokenOrder.products = List.of();
+        brokenOrder.requestAdd(token).statusCode(HTTP_BAD_REQUEST);
+
+        brokenOrder.products = null;
+        brokenOrder.requestAdd(token).statusCode(HTTP_BAD_REQUEST);
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderDeleteTests.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderDeleteTests.java
@@ -1,0 +1,40 @@
+package pw.mer.letsplay.order;
+
+import org.junit.jupiter.api.Test;
+import pw.mer.letsplay.AbstractControllerTests;
+import pw.mer.shared.SharedAuthFactory;
+
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static pw.mer.shared.RequestHelpers.authRequest;
+
+class OrderDeleteTests extends AbstractControllerTests {
+    @Test
+    void adminCanDeleteOrder() {
+        var seller = getSeller();
+        var buyer = new SharedAuthFactory.TestUser();
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+
+        var buyerToken = getAccessToken(buyer);
+        var orderId = testOrder.requestAdd(buyerToken).statusCode(HTTP_OK).extract().asString();
+
+        var adminToken = getAdminToken();
+        authRequest(adminToken).delete("/orders/" + orderId).then().statusCode(HTTP_OK);
+    }
+
+    @Test
+    void nonAdminCanNotDeleteOrder() {
+        var seller = getSeller();
+        var buyer = new SharedAuthFactory.TestUser();
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+
+        var buyerToken = getAccessToken(buyer);
+        var orderId = testOrder.requestAdd(buyerToken).statusCode(HTTP_OK).extract().asString();
+
+        var sellerToken = getAccessToken(seller);
+        authRequest(sellerToken).delete("/orders/" + orderId).then().statusCode(HTTP_FORBIDDEN);
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderSecurityTests.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderSecurityTests.java
@@ -1,0 +1,72 @@
+package pw.mer.letsplay.order;
+
+import org.junit.jupiter.api.Test;
+import pw.mer.letsplay.AbstractControllerTests;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.Matchers.is;
+import static pw.mer.shared.RequestHelpers.authRequest;
+import static pw.mer.shared.SharedAuthFactory.TestUser;
+
+class OrderSecurityTests extends AbstractControllerTests {
+    @Test
+    void canGetOwnOrders() {
+        var buyer = new TestUser();
+        var seller = getSeller();
+
+        var buyerToken = getAccessToken(buyer);
+        var sellerToken = getAccessToken(seller);
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+        var orderId = testOrder.requestAdd(buyerToken).statusCode(HTTP_OK).extract().asString();
+
+        testOrder.requestCheck(buyerToken, orderId);
+        testOrder.requestCheck(sellerToken, orderId);
+
+        authRequest(buyerToken).get("/orders").then().statusCode(HTTP_OK).body("$.size()", is(1));
+        authRequest(sellerToken).get("/orders").then().statusCode(HTTP_OK).body("$.size()", is(1));
+    }
+
+    @Test
+    void canNotGetOthersOrders() {
+        var buyer = new TestUser();
+        var seller = getSeller();
+
+        var buyerToken = getAccessToken(buyer);
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+        var orderId = testOrder.requestAdd(buyerToken).statusCode(HTTP_OK).extract().asString();
+
+        var unknownBuyer = new TestUser();
+        var unknownBuyerToken = getAccessToken(unknownBuyer);
+
+        authRequest(unknownBuyerToken).get("/orders/" + orderId).then().statusCode(HTTP_FORBIDDEN);
+        authRequest(unknownBuyerToken).get("/orders").then().statusCode(HTTP_OK).body("$.size()", is(0));
+
+        var unknownSeller = new TestUser(List.of("orders:read"));
+        var unknownSellerToken = getAccessToken(unknownSeller);
+
+        authRequest(unknownSellerToken).get("/orders/" + orderId).then().statusCode(HTTP_FORBIDDEN);
+        authRequest(unknownSellerToken).get("/orders").then().statusCode(HTTP_OK).body("$.size()", is(0));
+    }
+
+    @Test
+    void adminCanGetEverything() {
+        var adminToken = getAdminToken();
+
+        var buyer = new TestUser();
+        var seller = getSeller();
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+
+        var buyerToken = getAccessToken(buyer);
+        var orderId = testOrder.requestAdd(buyerToken).statusCode(HTTP_OK).extract().asString();
+
+        authRequest(adminToken).get("/orders/" + orderId).then().statusCode(HTTP_OK);
+        authRequest(adminToken).get("/orders").then().statusCode(HTTP_OK).body("$.size()", is(1));
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderUpdateTests.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/order/OrderUpdateTests.java
@@ -1,0 +1,64 @@
+package pw.mer.letsplay.order;
+
+import org.junit.jupiter.api.Test;
+import pw.mer.letsplay.AbstractControllerTests;
+import pw.mer.shared.SharedAuthFactory;
+
+import static java.net.HttpURLConnection.*;
+import static pw.mer.shared.RequestHelpers.jsonBodyRequest;
+
+class OrderUpdateTests extends AbstractControllerTests {
+
+    @Test
+    void updateOrderStatusValid() {
+        var seller = getSeller();
+        var buyer = new SharedAuthFactory.TestUser();
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+
+        String sellerToken = getAccessToken(seller);
+        String orderId = testOrder.requestAdd(sellerToken).statusCode(HTTP_OK).extract().asString();
+
+        jsonBodyRequest(sellerToken, "{\"status\": \"completed\"}")
+                .put("/orders/" + orderId)
+                .then().statusCode(HTTP_OK);
+
+        jsonBodyRequest(sellerToken, "{\"status\": \"canceled\"}")
+                .put("/orders/" + orderId)
+                .then().statusCode(HTTP_OK);
+    }
+
+    @Test
+    void invalidStatus() {
+        var seller = getSeller();
+        var buyer = new SharedAuthFactory.TestUser();
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+
+        String sellerToken = getAccessToken(seller);
+        String orderId = testOrder.requestAdd(sellerToken).statusCode(HTTP_OK).extract().asString();
+
+        jsonBodyRequest(sellerToken, "{\"status\": \"invalid\"}")
+                .put("/orders/" + orderId)
+                .then().statusCode(HTTP_BAD_REQUEST);
+    }
+
+    @Test
+    void buyerCanNotChangeStatus() {
+        var seller = getSeller();
+        var buyer = new SharedAuthFactory.TestUser();
+
+        var testOrder = new TestOrderFactory.TestOrder(buyer.getId(), seller.getId());
+
+        String buyerToken = getAccessToken(buyer);
+        String orderId = testOrder.requestAdd(buyerToken).statusCode(HTTP_OK).extract().asString();
+
+        jsonBodyRequest(buyerToken, "{\"status\": \"completed\"}")
+                .put("/orders/" + orderId)
+                .then().statusCode(HTTP_FORBIDDEN);
+
+        jsonBodyRequest(buyerToken, "{\"status\": \"cancelled\"}")
+                .put("/orders/" + orderId)
+                .then().statusCode(HTTP_FORBIDDEN);
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/order/TestOrderFactory.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/order/TestOrderFactory.java
@@ -1,0 +1,61 @@
+package pw.mer.letsplay.order;
+
+import io.restassured.response.ValidatableResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.minidev.json.annotate.JsonIgnore;
+
+import java.util.List;
+import java.util.UUID;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.hamcrest.Matchers.is;
+import static pw.mer.shared.RequestHelpers.authRequest;
+import static pw.mer.shared.RequestHelpers.jsonBodyRequest;
+
+public class TestOrderFactory {
+    @AllArgsConstructor
+    @Getter
+    public static class TestOrder {
+        @JsonIgnore
+        String buyer;
+
+        String seller;
+        Double totalPrice;
+
+        List<String> products;
+
+        public ValidatableResponse requestAdd(String token) {
+            return jsonBodyRequest(token, this).post("/orders/add").then();
+        }
+
+        /**
+         * Checks if `GET /orders/{orderId}` returns this order
+         *
+         * @param token   - token of user who has access to this order
+         * @param orderId - id of order to check
+         */
+        public void requestCheck(String token, String orderId) {
+            ValidatableResponse response = authRequest(token)
+                    .get("/orders/" + orderId)
+                    .then().statusCode(HTTP_OK)
+                    .body("buyer", is(buyer),
+                            "seller", is(seller),
+                            "totalPrice", is(totalPrice.floatValue())
+                    );
+
+            if (products != null) {
+                response.body("products", is(products));
+            }
+        }
+
+        public TestOrder(String buyer, String seller) {
+            this.buyer = buyer;
+            this.seller = seller;
+
+            this.totalPrice = Math.random() * 100;
+
+            this.products = List.of("Test product" + System.currentTimeMillis());
+        }
+    }
+}

--- a/backend/services/orders/src/test/java/pw/mer/letsplay/order/TestOrderFactory.java
+++ b/backend/services/orders/src/test/java/pw/mer/letsplay/order/TestOrderFactory.java
@@ -23,7 +23,15 @@ public class TestOrderFactory {
         String seller;
         Double totalPrice;
 
-        List<String> products;
+        @AllArgsConstructor
+        @Getter
+        public static class TestProduct {
+            String id;
+
+            Number quantity;
+        }
+
+        List<TestProduct> products;
 
         public ValidatableResponse requestAdd(String token) {
             return jsonBodyRequest(token, this).post("/orders/add").then();
@@ -45,7 +53,8 @@ public class TestOrderFactory {
                     );
 
             if (products != null) {
-                response.body("products", is(products));
+                response.body("products.size()", is(products.size()));
+                response.body("products[0].id", is(products.get(0).id));
             }
         }
 
@@ -55,7 +64,7 @@ public class TestOrderFactory {
 
             this.totalPrice = Math.random() * 100;
 
-            this.products = List.of("Test product" + System.currentTimeMillis());
+            this.products = List.of(new TestProduct(UUID.randomUUID().toString(), (int) (Math.random() * 10)));
         }
     }
 }

--- a/backend/services/users/src/main/java/pw/mer/letsplay/model/ERole.java
+++ b/backend/services/users/src/main/java/pw/mer/letsplay/model/ERole.java
@@ -17,8 +17,8 @@ public enum ERole {
 
     public List<String> getScopes() {
         return switch (this) {
-            case ADMIN -> List.of("users:admin", "products:admin", "media:write");
-            case SELLER -> List.of("products:write", "media:write");
+            case ADMIN -> List.of("users:admin", "products:admin", "media:write", "orders:admin");
+            case SELLER -> List.of("products:write", "media:write", "orders:write");
             default -> List.of();
         };
     }

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,2 +1,2 @@
 rootProject.name = "lets-play"
-include("services:users", "services:products", "services:media", "shared")
+include("services:users", "services:products", "services:media", "services:orders", "shared")

--- a/backend/shared/src/testFixtures/java/pw/mer/shared/SharedAuthFactory.java
+++ b/backend/shared/src/testFixtures/java/pw/mer/shared/SharedAuthFactory.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import pw.mer.shared.config.SharedJwtConfig;
 
 import java.util.List;
+import java.util.UUID;
 
 @UtilityClass
 public class SharedAuthFactory {
@@ -15,12 +16,12 @@ public class SharedAuthFactory {
         private final List<String> scopes;
 
         public TestUser() {
-            this.id = RandomStringUtils.randomAlphanumeric(5);
+            this.id = UUID.randomUUID().toString();
             this.scopes = List.of();
         }
 
         public TestUser(List<String> scopes) {
-            this.id = RandomStringUtils.randomAlphanumeric(5);
+            this.id = UUID.randomUUID().toString();
             this.scopes = scopes;
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,17 @@ services:
       - JWT_SECRET=${JWT_SECRET}
     volumes:
       - lets-play-media:/app/media
+  orders:
+    image: ghcr.io/merpw/lets-play-orders-service:${REVISION-main}
+    build:
+      context: backend
+      args:
+        - SERVICE_NAME=orders
+    environment:
+      - MONGO_HOST=db
+      - DOCS_API_URL=/api
+    depends_on:
+      - db
   frontend:
     image: ghcr.io/merpw/lets-play-frontend:${REVISION-main}
     platform: linux/amd64
@@ -73,7 +84,8 @@ services:
       URLS: "[
       {name:'Users',url:'/api/api-docs-users'},
       {name:'Products',url:'/api/api-docs-products'},
-      {name:'Media',url:'/api/api-docs-media'}
+      {name:'Media',url:'/api/api-docs-media'},
+      {name:'Orders',url:'/api/api-docs-orders'}
       ]"
       BASE_URL: /api/docs
 volumes:

--- a/nginx/common.conf
+++ b/nginx/common.conf
@@ -27,6 +27,13 @@ location /api {
         proxy_pass http://media:8080;
     }
 
+    location /api/orders {
+        rewrite ^/api/(.*)$ /$1 break;
+        # /api/orders -> /orders
+
+        proxy_pass http://orders:8080;
+    }
+
     location /api/docs {
         proxy_pass http://swagger-ui:8080;
     }

--- a/nginx/common.conf
+++ b/nginx/common.conf
@@ -55,4 +55,10 @@ location /api {
         rewrite ^ /v3/api-docs break;
         proxy_pass http://media:8080;
     }
+
+    location /api/api-docs-orders {
+        # rewrite to /v3/api-docs
+        rewrite ^ /v3/api-docs break;
+        proxy_pass http://orders:8080;
+    }
 }


### PR DESCRIPTION
This PR resolves #38 by adding a new `orders` microservice. All CRUD operations were implemented as well as tests.

- To place a new order, buyer can now call `POST /api/orders/add` with the following body: 

```json5
{
  "products": [
    {
      "id": "id-of-the-product",
      "quantity": 1
    },
   {
      "id": "id-of-the-second-product-product",
      "quantity": 5
    }
  ],
  "totalPrice": 120,
  "seller": "id-of-the-seller"
}
```

- To get info about specific order, both sellers and users can call `GET /api/orders/{id}`, which has the following fields: 

```json5
{
  "id": "id-of-the-order",
  "buyer": "id-of-the-buyer",
  "seller": "id-of-the-seller",
  "products": [
    {
      "id": "id-of-the-product",
      "quantity": 1
    },
   {
      "id": "id-of-the-second-product-product",
      "quantity": 5
    }
  ],
  "totalPrice": 120,
  "status": "pending", // status of the order, can be `pending`, `confirmed`, `completed` and `cancelled`
  "createdAt": 1703159308111 // order creation time in milliseconds
}
```

- Sellers can update the order by sending request to `PUT /api/orders`.  Only status can be updated for now: 

```json5
{
  "status": "completed"
}
```


- To get all orders, both sellers and buyers can use `GET /api/orders`, which returns array of orders, where the user is a seller or buyer. 

### Things that are a bit different from described in #38: 

- A new status `completed` was added
- `timestamp` was changed to `createdAt`, `userId` to `buyer` to avoid confusion<
- Users can not cancel orders for now, but it can be easilly implemented

Please feel free to provide feedback if there's anything else that needs to be added. Interactive documentation for new endpoints is available at `/api/docs`.