### PR TITLE
Add `docker compose pull` to deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,4 +41,5 @@ jobs:
             docker ps -aq | xargs docker rm -f
           fi
           docker system prune --force
+          docker compose pull
           docker compose up -d

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,5 +11,8 @@ services:
   media:
     image: ghcr.io/merpw/lets-play-media-service:latest
 
+  orders:
+    image: ghcr.io/merpw/lets-play-orders-service:latest
+
   frontend:
     image: ghcr.io/merpw/lets-play-frontend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       - lets-play-media:/app/media
   orders:
     image: ghcr.io/merpw/lets-play-orders-service:${REVISION-main}
+    platform: linux/amd64
     build:
       context: backend
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
     environment:
       - MONGO_HOST=db
       - DOCS_API_URL=/api
+      - JWT_SECRET=${JWT_SECRET}
     depends_on:
       - db
   frontend:


### PR DESCRIPTION
After merging #43 I found that the new endpoints are not available on production [buy-01.mer.pw/api/orders](https://buy-01.mer.pw/api/orders).

After short investigation I found that this happened because deployment workflow has not pulled the new versions of the images before starting. This bug caused using an old version of `nginx` packge, which did not have routes for the new service. Adding pull stage should fix this problem by always using the latest version of all packages.